### PR TITLE
Allows JSON fed charts to update data

### DIFF
--- a/addon/components/c3-chart.js
+++ b/addon/components/c3-chart.js
@@ -82,10 +82,13 @@ export default Ember.Component.extend({
   _retrieveCurrentIds: function() {
     var data = this.get('data');
     var rows = get(data, 'rows');
+    var keys = get(data, 'keys')
     var columns = get(data, 'columns');
     var currentIds;
 
-    if (rows) {
+    if (keys) {
+      currentIds = keys.value;
+    } else if (rows) {
       currentIds = rows[0];
     } else if (columns) {
       currentIds = columns.mapBy('firstObject');

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,9 @@
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
     "ember-qunit": "0.1.8",
     "ember-qunit-notifications": "0.0.4",
-    "qunit": "~1.15.0"
+    "qunit": "~1.15.0",
+    "c3": "~0.4.10",
+    "d3": "<=3.5.0"
   },
   "devDependencies": {
     "c3": "~0.4.9",


### PR DESCRIPTION
Currently this plugin only allows for array data charts to be bound and update. This PR allows for JSON based charts to also be bound and dynamically update. It does so through a change to the `_retrieveCurrentIds` allowing it to pull JSON keys, column keys, and row keys.
