### PR TITLE
Use ember-c3-shim instead of c3 global

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,8 +2,7 @@
   "predef": [
     "document",
     "window",
-    "-Promise",
-    "c3"
+    "-Promise"
   ],
   "browser": true,
   "boss": true,

--- a/addon/components/c3-chart.js
+++ b/addon/components/c3-chart.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import c3 from 'c3';
 
 const { get } = Ember;
 

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
     "ember": "1.13.7",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.8",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
@@ -13,6 +12,9 @@
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
     "c3": "~0.4.10",
+    "d3": "<=3.5.0"
+  },
+  "resolutions": {
     "d3": "<=3.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.1.2",
+    "ember-c3-shim": "0.0.2",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",
     "ember-cli-content-security-policy": "0.4.0",
@@ -31,10 +32,10 @@
     "ember-cli-release": "0.2.3",
     "ember-cli-sri": "^1.0.3",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "1.13.8",
+    "ember-d3": "0.1.0",
+    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
-    "ember-disable-prototype-extensions": "^1.0.0",
     "ember-try": "0.0.6"
   },
   "keywords": [


### PR DESCRIPTION
Globals are soooo 2014. This PR makes c3 available as an ES2015 module by way of [ember-c3-shim](https://github.com/mike-north/ember-c3-shim)
